### PR TITLE
adding launch_cf command-file utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ These tools help augment basic PBS Pro commands with capabilities desired by the
 
 * **qinteractive** - a script to quickly generate an interactive session
 * **qcmd** - a script that allows the user to run a command in an output-only (*but otherwise fully functional*) shell
+* **launch_cf** - a script that allows users to submit "command files" easily using PBS job arrays [(documentation)](https://ncar-hpc-docs.readthedocs.io/en/latest/pbs/job-scripts/#using-job-arrays-to-launch-a-command-file).
 
-The qinteractive script is also linked as `execcasper`, a variant that targets Casper by default.
+The `qinteractive` script is also linked as `execcasper`, a variant that targets Casper by default.
 
 ## Installation
 

--- a/bin/launch_cf
+++ b/bin/launch_cf
@@ -1,0 +1,186 @@
+#!/bin/bash
+
+#----------------------------------------------------------------------------
+# environment & site config, if any
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+#----------------------------------------------------------------------------
+
+launch_cf_PBS_script="${SCRIPTDIR}/../share/launch_cf.pbs"
+
+[ -f ${launch_cf_PBS_script} ] || { echo "ERROR: cannot locate ${launch_cf_PBS_script}"; exit 1; }
+
+#------------------------------------------------------------------
+# bash function to count lines not beginning with "#" from a text file
+count_non_comment_lines ()
+{
+    i=0
+    while read line; do
+	# skip comment lines beginning with "#"
+	[[ ${line:0:1} == "#" ]] && continue || i=$((i + 1))
+    done < "${1}"
+    echo ${i}
+    return 0
+}
+
+
+#------------------------------------------------------------------
+usage ()
+{
+    cat <<EOF
+${0} <-h|--help>
+     <--queue PBS_QUEUE>
+     <--ppn|--processors-per-node #CPUS>
+     <--steps-per-node #Steps/node>
+     <--nthreads|--threads-per-step #Threads/step>
+     <--mem|--memory RAM/node>
+     -A PBS_ACCOUNT -l walltime=01:00:00
+     ... other PBS args ...
+     <command file>
+
+#------------------------------------------------------------------
+Executes a series of commands in a file.  The filename
+may be listed as an argument, or defaults to "./cmdfile".
+
+All commands listed in the command file are executed
+relative to the submission directory.
+
+The optional bash configuration file "./config_env.sh" will
+be sourced prior to command execution, if found, and can therefore
+be used to customize the environment with e.g. "module load" commands.
+
+All options in "<>" brackets are optional.  Any unrecognized arguments
+are passed through directly to qsub.
+The PBS options -A and -l walltime are required at minimum.
+#------------------------------------------------------------------
+
+Examples:
+
+  # launches the commands listed in ./cmdfile:
+  ${0} -A PBS_ACCOUNT -l walltime=1:00:00
+
+  # launches the OpenMP-threaded commands listed in ./omp_cmdfile:
+  ${0} -A PBS_ACCOUNT -l walltime=1:00:00 --nthreads 4 --steps-per-node 32 ./omp_cmdfile
+EOF
+}
+
+#------------------------------------------------------------------
+parse_args ()
+{
+    unset args_for_pbs
+
+    while [ ${#} -gt 0 ] ; do
+        # check the first argument
+        case ${1} in
+
+            "-h"|"--help")
+                usage
+                shift
+                exit 1
+                ;;
+
+            "--queue")
+                shift
+                queue=${1}
+                shift
+                ;;
+
+            "--ppn"|"--processors-per-node")
+                shift
+                ppn=${1}
+                shift
+                ;;
+
+            "--steps-per-node")
+                shift
+                steps_per_node=${1}
+                shift
+                ;;
+
+            "--nthreads"|"--threads-per-step")
+                shift
+                threads_per_step=${1}
+                shift
+                ;;
+
+            "--mem"|"--memory")
+                shift;
+                memlimit=${1}
+                shift
+                ;;
+
+            *)
+                if [ -f ${1} ]; then
+                    command_file="${1}"
+                else
+                    args_for_pbs="${args_for_pbs} ${1}"
+                fi
+                shift # past argument
+                ;;
+        esac
+    done
+
+    return
+}
+
+#------------------------------------------------------------------
+# var defaults.
+command_file="./cmdfile"
+threads_per_step=1
+
+case "${NCAR_HOST}" in
+    "derecho")
+        ppn=128
+        memlimit="235G"
+        queue="main"
+        ;;
+    "casper")
+        # use less than full nodes on Casper.
+        ppn=8
+        memlimit="80G"
+        queue="casper"
+        ;;
+    "cheyenne")
+        ppn=36
+        memlimit="50G"
+        queue="regular"
+        ;;
+    *)
+        echo "ERROR: Unrecognized NCAR_HOST=${NCAR_HOST}"
+        exit 1
+esac
+
+# more defaults that depend on case above
+steps_per_node=${ppn}
+
+# finally, allow the user specify options
+parse_args $@
+
+#------------------------------------------------------------------
+# error & consistency checking
+[ -r ${command_file} ] || { echo "Cannot locate requested command file: ${command_file}"; exit 1; }
+[ $((${steps_per_node}*${threads_per_step})) -le ${ppn} ] || { echo "ERROR: ${steps_per_node}*${threads_per_step} > ${ppn}, check inputs!"; exit 1; }
+
+#------------------------------------------------------------------
+# main execution follows...
+n_total_steps=$(count_non_comment_lines ${command_file})
+
+echo "Found n_total_steps=${n_total_steps} in ${command_file}"
+
+#------------------------------------------------------------------
+njobs=$(( ${n_total_steps} / ${steps_per_node} ))
+ # evenly divisible?
+[ $(( ${njobs} * ${steps_per_node} )) -eq ${n_total_steps} ] && njobs=$((${njobs}-1))
+echo "Running $((${njobs}+1)) jobs with ${steps_per_node} steps / node on NCAR resource ${NCAR_HOST}"
+
+
+# hackery: PBS will not allow us to submit a 1-entry array.
+# for that case we will be submitted without a -J arg
+[ ${njobs} -gt 0 ] && args_for_pbs="-J 0-${njobs} ${args_for_pbs}"
+
+ss="1:ncpus=${ppn}:mpiprocs=${steps_per_node}:ompthreads=${threads_per_step}:mem=${memlimit}"
+
+set -x
+qsub -v command_file="${command_file}" \
+     -q ${queue} -l select=${ss} \
+     ${args_for_pbs} \
+     ${launch_cf_PBS_script}

--- a/share/launch_cf.pbs
+++ b/share/launch_cf.pbs
@@ -1,0 +1,116 @@
+#!/bin/bash
+#PBS -N launch_cf
+#PBS -j oe
+
+#------------------------------------------------------------------
+# bash function to count lines not beginning with "#" from a text file
+count_non_comment_lines ()
+{
+    i=0
+    while read line; do
+	# skip comment lines beginning with "#"
+	[[ ${line:0:1} == "#" ]] && continue || i=$((i + 1))
+    done < "${1}"
+    echo ${i}
+    return 0
+}
+#------------------------------------------------------------------
+
+#------------------------------------------------------------------
+# bash function to extract the desired line number from a text file
+# (0-based indexing)
+getline_from_file ()
+{
+    # ref: https://www.baeldung.com/linux/read-specific-line-from-file
+    FILE="${1}"
+    LINE_NO=${2}
+
+    i=0
+    while read line; do
+        # skip comment lines beginning with "#"
+        [[ ${line:0:1} == "#" ]] && continue
+
+        test ${i} = ${LINE_NO} && echo "${line}" && return
+        i=$((i + 1))
+    done < "${FILE}"
+
+    echo "ERROR: line ${LINE_NO} not found, is ${FILE} too short? (only found ${i} non-comment lines)"
+    exit 1
+}
+#------------------------------------------------------------------
+
+tstart=$(date +%s)
+
+env | egrep "PBS|THREAD" | sort | uniq
+
+### Set temp to scratch, if ${SCRATCH } is set
+[ -n ${SCRATCH} ] && export TMPDIR=${SCRATCH}/tmp && mkdir -p ${TMPDIR}
+
+# potentially source a users requested environment configuration
+[ -f ./config_env.sh ] && . ./config_env.sh
+
+# command file to read, potentially from environment
+command_file="${command_file:-./cmdfile}"
+[ -r ${command_file} ] || { echo "Cannot locate requested command file: ${command_file}"; exit 1; }
+
+## determine the number of nodes, and processors per node we were assigned
+## (inferred from the ${PBS_NODEFILE})
+nodeslist=( $(cat ${PBS_NODEFILE} | sort | uniq | cut -d'.' -f1) )
+nnodes=$(cat ${PBS_NODEFILE} | sort | uniq | wc -l)
+nranks=$(cat ${PBS_NODEFILE} | sort | wc -l)
+nranks_per_node=$((${nranks} / ${nnodes}))
+
+[ ${nnodes} -eq 1 ] || { echo "ERROR: this example is intended to be run on 1 node, but with perhaps many array steps"; exit 1; }
+
+echo "(#steps/node) x (#threads/step) = ${nranks_per_node} x ${OMP_NUM_THREADS}"
+
+n_total_steps=$(count_non_comment_lines ${command_file})
+
+# hackery: PBS will not allow us to submit a 1-entry array.
+# so for that case we will be submitted without a -J arg, yet
+# still want the PBS_ARRAY_INDEX and PBS_ARRAY_ID defined...
+if [ -z "${PBS_ARRAY_INDEX}" ]; then
+    PBS_ARRAY_INDEX=0
+    PBS_ARRAY_ID=${PBS_JOBID}
+fi
+
+
+# this PBS_ARRAY_INDEX will compute multiple "steps" from ${command_file}, up to ppn
+start_idx=$(( ${PBS_ARRAY_INDEX} * ${nranks_per_node} ))
+stop_idx=$(( ${start_idx} + ${nranks_per_node} - 1 ))
+
+echo "n_total_steps: ${n_total_steps}, PBS_ARRAY_INDEX=${PBS_ARRAY_INDEX}"
+echo "start_idx=${start_idx} stop_idx=${stop_idx} "
+
+# create a logs directory to hold stdout from each process
+logs_dir=stdout-${PBS_ARRAY_ID/"[]"/}
+mkdir -p ./${logs_dir}
+
+# loop over each 'step' for which we are responsible.
+# launch our ${command_file} lines, in the background
+for step in $(seq ${start_idx} ${stop_idx}); do
+
+    # the last PBS_ARRAY_INDEX could go past n_total_steps if the number of ${command_file}
+    # is not evenly divisible by ppn - don't let it
+    [ ${step} -ge ${n_total_steps} ] && break
+
+    # get the command line arguments from ${command_file} for this step.
+    # handles # comment lines in step too...)
+    step_cmd=$(getline_from_file ${command_file} ${step} | cut -d'#' -f1)
+
+    echo "   launching step $((${step}+1)): ${step_cmd}"
+
+    # finally, launch our desired application with the requested arguments.  Redirect stdout/stderr to
+    # the logs directory.
+    eval "$step_cmd" > ./${logs_dir}/step-$(printf '%05d' $((${step}+1)) ).out 2>&1 &
+done
+
+# wait for all the background processes to complete.
+# (otherwise, when this script exits, PBS thinks it is done and will kill any remaining processes...)
+wait
+
+#----------------
+tstop=$(date +%s)
+elapsed=$((${tstop} - ${tstart}))
+
+echo "Done: PBS_ARRAY_INDEX=${PBS_ARRAY_INDEX} took ${elapsed} seconds, finished on $(date)"


### PR DESCRIPTION
`./bin/launch_cf` implements [this functionality](https://ncar-hpc-docs.readthedocs.io/en/latest/pbs/job-scripts/#using-job-arrays-to-launch-a-command-file).

Created a `./share` subdirectory and added the supporting PBS script there.

As future work, could refactor `launch_cf` to pull common config (e.g. machine/ppn) from `./etc/<mach>.conf`